### PR TITLE
Fix: Replace "class" in KoFiButton with "className"

### DIFF
--- a/src/KoFiButton.js
+++ b/src/KoFiButton.js
@@ -20,7 +20,7 @@ export default function KoFiButton({
           <span class="kofitext">
             <img
               src="https://ko-fi.com/img/cup-border.png"
-              class="kofiimg"
+              className="kofiimg"
               alt="Ko-Fi button"
             />
             {label?label:null}

--- a/src/KoFiButton.js
+++ b/src/KoFiButton.js
@@ -8,7 +8,7 @@ export default function KoFiButton({
 }) {
   return (
     <div className="flex  justify-start">
-      <div class="btn-container">
+      <div className="btn-container">
         <a
           title={label}
           className={`${label?'kofi-button ':`rounded-full ${size?size:'w-10 h-10'} block flex justify-center`} rounded-full`}
@@ -17,7 +17,7 @@ export default function KoFiButton({
           target="_blank"
           rel="noopener noreferrer"
         >
-          <span class="kofitext">
+          <span className="kofitext">
             <img
               src="https://ko-fi.com/img/cup-border.png"
               className="kofiimg"


### PR DESCRIPTION
Simple fix to use "className" attribute instead of "class" in the KoFiButton component. (Was getting warnings and wanted to clean up.)